### PR TITLE
[FEATURE] Enable Symfony ruleset in DefaultRuleset

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -27,8 +27,8 @@ use Rector\Set\ValueObject\LevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
-        __DIR__ . '/src',
-        __DIR__ . '/tests',
+        __DIR__.'/src',
+        __DIR__.'/tests',
     ]);
 
     $rectorConfig->sets([

--- a/src/Rule/DefaultRuleset.php
+++ b/src/Rule/DefaultRuleset.php
@@ -39,6 +39,7 @@ final class DefaultRuleset implements Ruleset
     {
         return [
             '@PER-CS' => true,
+            '@Symfony' => true,
             'global_namespace_import' => [
                 'import_classes' => true,
                 'import_functions' => true,
@@ -50,6 +51,7 @@ final class DefaultRuleset implements Ruleset
                     'function',
                 ],
             ],
+            'single_line_empty_body' => true,
             'trailing_comma_in_multiline' => [
                 'elements' => [
                     'arguments',

--- a/tests/src/Rule/DefaultRulesetTest.php
+++ b/tests/src/Rule/DefaultRulesetTest.php
@@ -28,7 +28,7 @@ use PhpCsFixer\Config;
 use PHPUnit\Framework;
 
 /**
- * DefaultRulesetTest
+ * DefaultRulesetTest.
  *
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-3.0-or-later

--- a/tests/src/Rule/DefaultRulesetTest.php
+++ b/tests/src/Rule/DefaultRulesetTest.php
@@ -57,13 +57,13 @@ final class DefaultRulesetTest extends Framework\TestCase
     public function applyMergesRulesFromRulesetWithRulesFromConfigObject(): void
     {
         $this->config->setRules([
-            '@Symfony' => true,
+            '@PSR12' => true,
         ]);
 
         $this->subject->apply($this->config, true);
 
         $expected = $this->subject->getRules();
-        $expected['@Symfony'] = true;
+        $expected['@PSR12'] = true;
 
         self::assertEquals($expected, $this->config->getRules());
     }


### PR DESCRIPTION
This PR enables the `@Symfony` ruleset in `DefaultRuleset`, along with `single_line_empty_body` enabled.